### PR TITLE
ADD: EFS Improvements

### DIFF
--- a/cf.yml
+++ b/cf.yml
@@ -196,7 +196,11 @@ Resources:
 
   Efs:
     Type: AWS::EFS::FileSystem
-    Properties: {}
+    DeletionPolicy: Retain
+    Properties:
+      LifecyclePolicies:
+      - TransitionToIA: AFTER_7_DAYS
+      - TransitionToPrimaryStorageClass: AFTER_1_ACCESS
 
   MountA:
     Type: AWS::EFS::MountTarget
@@ -271,17 +275,10 @@ Resources:
       UserData:
         Fn::Base64: !Sub |
           #!/bin/bash -xe
-          yum install -y amazon-efs-utils
-          mkdir /opt/factorio
-          mount -t efs ${Efs}:/ /opt/factorio
-          chown 845:845 /opt/factorio
           echo ECS_CLUSTER=${EcsCluster} >> /etc/ecs/ecs.config          
 
   AutoScalingGroup:
     Type: AWS::AutoScaling::AutoScalingGroup
-    DependsOn:
-    - MountA
-    - MountB
     Properties:
       AutoScalingGroupName: !Sub "${AWS::StackName}-asg"
       DesiredCapacity: !FindInMap [ ServerState, !Ref ServerState, DesiredCapacity ]
@@ -339,11 +336,15 @@ Resources:
 
   EcsTask:
     Type: AWS::ECS::TaskDefinition
+    DependsOn:
+    - MountA
+    - MountB
     Properties: 
       Volumes:
-      - Host:
-          SourcePath: /opt/factorio
-        Name: factorio
+      - Name: factorio
+        EFSVolumeConfiguration:
+          FilesystemId: !Ref Efs
+          TransitEncryption: ENABLED
       ContainerDefinitions:
         - Name: factorio
           MemoryReservation: 1024

--- a/readme.md
+++ b/readme.md
@@ -49,7 +49,8 @@ For example, here is how you copy your Save File to the running server:
 ``` bash
 scp MySave.zip ec2-user@<my-domain-or-EC2-ip>:~/
 ssh ec2-user@<my-domain-or-EC2-ip>
-mv ~/MySave.zip /opt/factorio/saves
+sudo savedir=$(mount | grep nfs4 | cut -f3 -d ' ' | xargs -I {} echo "{}/saves")
+sudo mv ~/MySave.zip $savedir
 ```
 
 Then your save should be in place.
@@ -93,7 +94,7 @@ Update your CloudFormation stack. Change the server state parameter from "Runnin
 
 **I'm done with Factorio, how do I delete this server?** 
 
-Delete the CloudFormation stack. Done.
+Delete the CloudFormation stack.  Except for the EFS, Done.  The EFS is retained when the CloudFormation stack is deleted to preserve your saves, but can then be manually deleted.
 
 **How can I upgrade the Factorio version?** 
 
@@ -140,7 +141,7 @@ In order to load an existing save, follow the below steps:
 The two key components that will attract charges are:
 
 * **EC2** - If you're using spot pricing (and the m3.medium instance as per the default in the template), I doubt you would attract more than a cent an hour in fees for EC2. Even if you ran it 24 hours a day for a whole month, that's about 7 bucks.
-* **EFS** - Charged per Gigabyte stored per month (GB-Month). Varies based on region, but typically less than 50c per gigabyte. My EFS file system for Factorio is only about 100MB (incl. mods and 5 saves), so maybe 5 cents per month?
+* **EFS** - Charged per Gigabyte stored per month (GB-Month). Varies based on region, but typically less than 50c per gigabyte. My EFS file system for Factorio is only about 100MB (incl. mods and 5 saves), so maybe 5 cents per month?  To lower storage costs when not actively utilzied, items in EFS are automatically moved to Infrequent Access after 7 days and also moved back to Standard if subsequently accessed.
 
 AWS do charge for data egress (i.e. data being sent from your Factorio server to clients), but again this should be barely noticeable.
 


### PR DESCRIPTION
-EFS retained upon stack deletion to preserve saves.
-EFS lifecycle management enabled to lower cost when not actively utilized.
-Migrate to CloudFormation's native EFS handler for ECS tasks.  Removes the ASG dependency on the EFS mount points for increased parallelization during build-out.  However, migrating save files is slightly complicated.