### PR TITLE
python3.7 -> python3.12

### DIFF
--- a/cf.yml
+++ b/cf.yml
@@ -434,7 +434,7 @@ Resources:
       Handler: index.handler
       MemorySize: 128
       Role: !GetAtt SetDNSRecordLambdaRole.Arn
-      Runtime: python3.7
+      Runtime: python3.12
       Timeout: 20
 
   LaunchEvent:


### PR DESCRIPTION
Python 3.7 is EOL: https://devguide.python.org/versions/
I tested this by uploading the new yaml, fetching the IP of my factorio subdomain (just using ping to print out the IP), changing the CF stack state to "stopped" then back to "running", and fetching the new IP of my factorio subdomain.