### PR TITLE
Add optional argument for ssh key path in utils

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -69,6 +69,12 @@ Use the automation in `util/upload-save.bash` to upload your save file to your s
 bash util/upload-save.bash ~/path/to/my/save.zip $your_ec2_ip_or_remote_name
 ```
 
+Optionally, you can specify a path to a private key with a bash variable rather than relying on default ssh keys.
+
+``` bash
+FACTORIO_PEM=~/path/to/my.pem bash util/upload-save.bash ~/path/to/my/save.zip $your_ec2_ip_or_remote_name
+```
+
 This is just an automated implementation of the slower version below.
 
 ##### Fast save download (Recommended)
@@ -77,6 +83,12 @@ Use the automation in `util/download-latest-save.bash` to download the latest (m
 
 ``` bash
 bash util/download-latest-save.bash $your_ec2_ip_or_remote_name
+```
+
+Optionally, you can specify a path to a private key with a bash variable rather than relying on default ssh keys.
+
+``` bash
+FACTORIO_PEM=~/path/to/my.pem bash util/download-latest-save.bash $your_ec2_ip_or_remote_name
 ```
 
 Your server needs to be running for this to work and it should download your latest save to your local directory.

--- a/util/download-latest-save.bash
+++ b/util/download-latest-save.bash
@@ -1,17 +1,17 @@
 #!/bin/bash
 
 # Check if remote name is provided
-if [ $# -ne 1 -a $# -ne 2 ]; then
-    echo "Usage: $0 <remote_name> [optional_path_to_MyKey.pem]"
+if [ $# -ne 1 ]; then
+    echo "Usage: $0 <remote_name>"
     exit 1
 fi
 
 remote_name="$1"
 key_path=""
 
-# Check if remote name is provided
-if [ $# -eq 2 ]; then
-    key_path="-i $2"
+# Check if custom PEM file is provided
+if [ -n "$FACTORIO_PEM" ]; then
+    key_path="-i $FACTORIO_PEM"
 fi
 
 # Generate a human-readable timestamp

--- a/util/download-latest-save.bash
+++ b/util/download-latest-save.bash
@@ -1,18 +1,26 @@
 #!/bin/bash
 
 # Check if remote name is provided
-if [ $# -ne 1 ]; then
-    echo "Usage: $0 <remote_name>"
+if [ $# -ne 1 -a $# -ne 2 ]; then
+    echo "Usage: $0 <remote_name> [optional_path_to_MyKey.pem]"
     exit 1
 fi
 
 remote_name="$1"
+key_path=""
+
+# Check if remote name is provided
+if [ $# -eq 2 ]; then
+    key_path="-i $2"
+fi
 
 # Generate a human-readable timestamp
 timestamp=$(date +"%Y-%m-%d_%H-%M-%S")
 
+
+
 # SSH into the remote instance to find the most recent save file
-ssh_output=$(ssh "ec2-user@$remote_name" << EOF
+ssh_output=$(ssh $key_path "ec2-user@$remote_name" << EOF
     # Record the current directory
     current_dir=\$(pwd)
 
@@ -59,9 +67,9 @@ latest_file=$(basename "$latest_file_path")
 
 # Download the file from the remote instance to the current local directory with the new filename
 new_filename="${remote_name}_${timestamp}_${latest_file}"
-scp "ec2-user@$remote_name:$latest_file_path" "./$new_filename"
+scp $key_path "ec2-user@$remote_name:$latest_file_path" "./$new_filename"
 
 # Clean up the temporary file on the remote instance
-ssh "ec2-user@$remote_name" "rm -f $latest_file_path"
+ssh $key_path "ec2-user@$remote_name" "rm -f $latest_file_path"
 
 echo "Download complete. The latest save file has been saved as '$new_filename' in your current directory."

--- a/util/upload-save.bash
+++ b/util/upload-save.bash
@@ -1,14 +1,20 @@
 #!/bin/bash
 
 # Check if both arguments are provided
-if [ $# -ne 2 ]; then
-    echo "Usage: $0 <path_to_MySave.zip> <ec2_address>"
+if [ $# -ne 2 -a $# -ne 3 ]; then
+    echo "Usage: $0 <path_to_MySave.zip> <ec2_address> [optional_path_to_MyKey.pem]"
     exit 1
 fi
 
 # Get the file path and EC2 address from command line arguments
 save_file="$1"
 ec2_address="$2"
+key_path=""
+
+# Check if remote name is provided
+if [ $# -eq 3 ]; then
+    key_path="-i $3"
+fi
 
 # Check if the file exists
 if [ ! -f "$save_file" ]; then
@@ -18,10 +24,10 @@ fi
 
 # Upload the save file to the EC2 instance
 echo "Uploading save file to EC2 instance..."
-scp "$save_file" "ec2-user@$ec2_address:~/"
+scp $key_path "$save_file" "ec2-user@$ec2_address:~/"
 
 # SSH into the EC2 instance and perform the required operations
-ssh "ec2-user@$ec2_address" << EOF
+ssh $key_path "ec2-user@$ec2_address" << EOF
     # Get the Factorio container ID
     container_id=\$(docker ps | grep factoriotools/factorio | awk '{print \$1}' | cut -c1-3)
 

--- a/util/upload-save.bash
+++ b/util/upload-save.bash
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 # Check if both arguments are provided
-if [ $# -ne 2 -a $# -ne 3 ]; then
-    echo "Usage: $0 <path_to_MySave.zip> <ec2_address> [optional_path_to_MyKey.pem]"
+if [ $# -ne 2 ]; then
+    echo "Usage: $0 <path_to_MySave.zip> <ec2_address>"
     exit 1
 fi
 
@@ -11,9 +11,9 @@ save_file="$1"
 ec2_address="$2"
 key_path=""
 
-# Check if remote name is provided
-if [ $# -eq 3 ]; then
-    key_path="-i $3"
+# Check if custom PEM file is provided
+if [ -n "$FACTORIO_PEM" ]; then
+    key_path="-i $FACTORIO_PEM"
 fi
 
 # Check if the file exists


### PR DESCRIPTION
### Notes
- Updates the download-latest-save script to allow 1 or 2 arguments. If a second argument is provided it will be used to specify a key path with the "-i" argument for ssh and scp.
- Updates the upload-save script to allow 2 or 3 arguments. If a second argument is provided it will be used to specify a key path with the "-i" argument for ssh and scp.

### Testing
Verified the following cases for proper behavior
- Ran both scripts without optional argument (permission denied, expected)
- Ran both scripts with new optional key path argument (successful)
- Ran both scripts with zero arguments (Usage text output to console)
- Ran both scripts with 3 and 4 arguments (Usage text output to console)