### PR TITLE
Add Auto-update support

### DIFF
--- a/cf.yml
+++ b/cf.yml
@@ -92,6 +92,14 @@ Parameters:
     - true
     - false
 
+  AutoUpdateServer:
+    Type: String
+    Description: If enabled, the server will automatically update to the latest version when it becomes available.
+    Default: false
+    AllowedValues:
+    - true
+    - false
+
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
@@ -103,6 +111,7 @@ Metadata:
         - ServerState
         - EnableRcon
         - UpdateModsOnStart
+        - AutoUpdateServer
       - Label:
           default: Instance Configuration
         Parameters:
@@ -142,6 +151,8 @@ Metadata:
         default: "Do you wish to enable RCON?"
       UpdateModsOnStart:
         default: "Do you wish to update your mods on container start"
+      AutoUpdateServer:
+        default: "Should the server automatically update when new versions are available?"
 Conditions:
   KeyPairNameProvided: !Not [ !Equals [ !Ref KeyPairName, '' ] ]
   IpAddressProvided: !Not [ !Equals [ !Ref YourIp, '' ] ]
@@ -149,6 +160,7 @@ Conditions:
   DoEnableRcon: !Equals [ !Ref EnableRcon, 'true' ]
   UsingSpotInstance: !Equals [ !Ref InstancePurchaseMode, 'Spot' ]
   InstanceTypeProvided: !Not [ !Equals [ !Ref InstanceType, '' ] ]
+  AutoUpdateEnabled: !Equals [ !Ref AutoUpdateServer, 'true' ]
 
 Mappings:
   ServerState:
@@ -519,7 +531,279 @@ Resources:
       Action: lambda:InvokeFunction
       FunctionName: !GetAtt SetDNSRecordLambda.Arn
       Principal: events.amazonaws.com
-      SourceArn: !GetAtt LaunchEvent.Arn
+
+  # ====================================================
+  # AUTO UPDATE CONFIGURATION
+  # ====================================================
+
+  AutoUpdateLambda:
+    Type: AWS::Lambda::Function
+    Condition: AutoUpdateEnabled
+    Properties:
+      Role: !GetAtt AutoUpdateLambdaRole.Arn
+      Runtime: python3.12
+      Handler: index.handler
+      Timeout: 300  # 5 minutes
+      Environment:
+        Variables:
+          STACK_NAME: !Ref AWS::StackName
+      Code:
+        ZipFile: |
+          import boto3
+          import os
+          import json
+          import urllib.request
+          import logging
+          import time
+          from urllib.error import URLError
+
+          logger = logging.getLogger()
+          logger.setLevel(logging.INFO)
+
+          def make_request(url, timeout=5):
+              try:
+                  req = urllib.request.Request(
+                      url,
+                      headers={'User-Agent': 'AWS Lambda Function'}
+                  )
+                  with urllib.request.urlopen(req, timeout=timeout) as response:
+                      return json.loads(response.read().decode())
+              except URLError as e:
+                  logger.error(f"Failed to fetch {url}: {str(e)}")
+                  raise
+              except Exception as e:
+                  logger.error(f"Error processing {url}: {str(e)}")
+                  raise
+
+          def get_dockerhub_tag():
+              try:
+                  # Get stable tag info
+                  stable_data = make_request("https://hub.docker.com/v2/repositories/factoriotools/factorio/tags/stable")
+                  stable_digest = stable_data.get('digest')
+                  if not stable_digest:
+                      raise ValueError("Could not get stable digest")
+
+                  # Get version tags
+                  tags_data = make_request("https://hub.docker.com/v2/repositories/factoriotools/factorio/tags?page_size=100")
+                  for tag in tags_data.get('results', []):
+                      if tag.get('digest') == stable_digest and tag.get('name').replace('.', '').isdigit():
+                          return tag.get('name')
+                  return None
+              except Exception as e:
+                  logger.error(f"Error in get_dockerhub_tag: {str(e)}")
+                  raise
+
+          def get_current_version(cfn_client, stack_name):
+              try:
+                  response = cfn_client.describe_stacks(StackName=stack_name)
+                  for param in response['Stacks'][0]['Parameters']:
+                      if param['ParameterKey'] == 'FactorioImageTag':
+                          return param['ParameterValue']
+                  return None
+              except Exception as e:
+                  logger.error(f"Error getting current version: {str(e)}")
+                  raise
+
+          def wait_for_stack_update(cfn_client, stack_name, max_wait_seconds=240):
+              """
+              Waits for stack update to complete and returns the final status.
+              """
+              start_time = time.time()
+              while time.time() - start_time < max_wait_seconds:
+                  try:
+                      response = cfn_client.describe_stacks(StackName=stack_name)
+                      status = response['Stacks'][0]['StackStatus']
+                      
+                      if status == 'UPDATE_COMPLETE':
+                          return True, "Stack update completed successfully"
+                      elif status == 'UPDATE_ROLLBACK_COMPLETE':
+                          events = cfn_client.describe_stack_events(StackName=stack_name)
+                          for event in events['StackEvents']:
+                              if event['ResourceStatus'].endswith('FAILED'):
+                                  return False, f"Stack update rolled back. Reason: {event.get('ResourceStatusReason', 'Unknown error')}"
+                          return False, "Stack update rolled back"
+                      elif status.endswith('FAILED'):
+                          events = cfn_client.describe_stack_events(StackName=stack_name)
+                          for event in events['StackEvents']:
+                              if event['ResourceStatus'].endswith('FAILED'):
+                                  return False, f"Stack update failed. Reason: {event.get('ResourceStatusReason', 'Unknown error')}"
+                          return False, f"Stack update failed with status: {status}"
+                      
+                      logger.info(f"Current stack status: {status}")
+                      time.sleep(10)
+                      
+                  except Exception as e:
+                      logger.error(f"Error checking stack status: {str(e)}")
+                      return False, f"Error checking stack status: {str(e)}"
+              
+              return False, f"Timeout waiting for stack update after {max_wait_seconds} seconds"
+
+          def update_stack_parameter(cfn_client, stack_name, version):
+              """
+              Updates the FactorioImageTag parameter in the CloudFormation stack.
+              """
+              try:
+                  response = cfn_client.describe_stacks(StackName=stack_name)
+                  current_params = response['Stacks'][0]['Parameters']
+                  
+                  new_params = [
+                      {'ParameterKey': 'FactorioImageTag', 'ParameterValue': version}
+                      if param['ParameterKey'] == 'FactorioImageTag'
+                      else {'ParameterKey': param['ParameterKey'], 'UsePreviousValue': True}
+                      for param in current_params
+                  ]
+                  
+                  cfn_client.update_stack(
+                      StackName=stack_name,
+                      UsePreviousTemplate=True,
+                      Parameters=new_params,
+                      Capabilities=['CAPABILITY_IAM']
+                  )
+                  logger.info(f"Stack update initiated with FactorioImageTag={version}")
+                  
+                  return wait_for_stack_update(cfn_client, stack_name)
+                  
+              except cfn_client.exceptions.ClientError as e:
+                  error_message = str(e)
+                  if 'No updates are to be performed' in error_message:
+                      return True, "No updates needed - parameters already set to desired values"
+                  logger.error(f"CloudFormation update error: {error_message}")
+                  return False, f"Failed to update stack: {error_message}"
+              except Exception as e:
+                  error_message = str(e)
+                  logger.error(f"Unexpected error during stack update: {error_message}")
+                  return False, f"Unexpected error: {error_message}"
+
+          def handler(event, context):
+              try:
+                  cfn = boto3.client('cloudformation')
+                  stack_name = os.environ['STACK_NAME']
+
+                  current_version = get_current_version(cfn, stack_name)
+                  latest_version = get_dockerhub_tag()
+                  if not latest_version:
+                      return {
+                          'statusCode': 500,
+                          'body': json.dumps({
+                              'success': False,
+                              'message': "Could not determine latest version"
+                          })
+                      }
+                  
+                  logger.info(f"Current version: {current_version}, Latest version: {latest_version}")
+                  if latest_version != current_version:
+                      logger.info(f"Updating stack to latest version: {latest_version}")
+                      success, update_message = update_stack_parameter(cfn, stack_name, latest_version)
+                      logger.info(f"Update result: {success}, Message: {update_message}")
+                      return {
+                          'statusCode': 200 if success else 500,
+                          'body': json.dumps({
+                              'success': success,
+                              'message': update_message,
+                              'oldVersion': current_version,
+                              'newVersion': latest_version
+                          })
+                      }
+                  message = f"No update needed - current version is {current_version}"
+                  logger.info(message)
+                  return {
+                      'statusCode': 200,
+                      'body': json.dumps({
+                          'success': True,
+                          'message': message,
+                          'currentVersion': current_version
+                      })
+                  }
+
+              except Exception as e:
+                  logger.error(f"Error in handler: {str(e)}")
+                  return {
+                      'statusCode': 500,
+                      'body': json.dumps({
+                          'success': False,
+                          'message': f"Error occurred: {str(e)}"
+                      })
+                  }
+
+  AutoUpdateLambdaRole:
+    Type: AWS::IAM::Role
+    Condition: AutoUpdateEnabled
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Policies:
+        - PolicyName: AutoUpdateAccess
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - ecs:RegisterTaskDefinition
+                  - ecs:DeregisterTaskDefinition
+                  - ecs:DescribeTaskDefinition
+                  - ecs:ListTaskDefinitions
+                  - ecs:DescribeServices
+                  - ecs:UpdateService
+                  - ecs:ListServices
+                  - ecs:DescribeClusters
+                  - ecs:ListTasks
+                  - ecs:DescribeTasks
+                  - ecs:StopTask
+                  - iam:PassRole
+                Resource:
+                  - !Sub 'arn:aws:ecs:${AWS::Region}:${AWS::AccountId}:cluster/${EcsCluster}'
+                  - !Sub 'arn:aws:ecs:${AWS::Region}:${AWS::AccountId}:service/${EcsCluster}/*'
+                  - !Sub 'arn:aws:ecs:${AWS::Region}:${AWS::AccountId}:task-definition/${AWS::StackName}*'
+                  - !Sub 'arn:aws:ecs:${AWS::Region}:${AWS::AccountId}:task/${EcsCluster}/*'
+                  - !GetAtt InstanceRole.Arn
+              - Effect: Allow
+                Action:
+                  - ecs:DeregisterTaskDefinition
+                Resource: "*"
+              - Effect: Allow
+                Action:
+                  - cloudformation:DescribeStacks
+                  - cloudformation:UpdateStack
+                  - cloudformation:DescribeStackEvents
+                Resource:
+                  - !Sub 'arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/${AWS::StackName}/*'
+              - Effect: Allow
+                Action:
+                  - ssm:GetParameters
+                  - ssm:GetParameter
+                Resource:
+                  - !Sub 'arn:aws:ssm:${AWS::Region}::parameter/aws/service/ecs/*'
+              - Effect: Allow
+                Action:
+                  - ec2:DescribeImages
+                Resource: "*"
+
+  AutoUpdateScheduleRule:
+    Type: AWS::Events::Rule
+    Condition: AutoUpdateEnabled
+    Properties:
+      Description: "Schedule for checking Factorio updates daily at 7:15 AM Eastern"
+      ScheduleExpression: "cron(15 11 * * ? *)"
+      State: ENABLED
+      Targets:
+        - Arn: !GetAtt AutoUpdateLambda.Arn
+          Id: !Sub "${AWS::StackName}-auto-update-target"
+
+  AutoUpdateLambdaPermission:
+    Type: AWS::Lambda::Permission
+    Condition: AutoUpdateEnabled
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName: !GetAtt AutoUpdateLambda.Arn
+      Principal: events.amazonaws.com
+      SourceArn: !GetAtt AutoUpdateScheduleRule.Arn
 
 Outputs:
   CheckInstanceIp:

--- a/tests/teste2eupdater.sh
+++ b/tests/teste2eupdater.sh
@@ -1,0 +1,208 @@
+#!/bin/bash
+set -e # Exit on any error
+# Set default values that can be overridden by environment variables
+STACK_NAME=${STACK_NAME:-"factorio-server-test"}
+REGION="us-east-1"
+FACTORIO_IMAGE_TAG=${FACTORIO_IMAGE_TAG:-"2.0.30"}
+SERVER_STATE=${SERVER_STATE:-"Running"}
+HOSTED_ZONE_ID=${HOSTED_ZONE_ID:-""}
+RECORD_NAME=${RECORD_NAME:-""}
+
+function get_versions() {
+  echo "\n🔍 Getting current stack parameters..."
+  STACK_VERSION=$(aws cloudformation describe-stacks \
+    --stack-name $STACK_NAME \
+    --query 'Stacks[0].Parameters[?ParameterKey==`FactorioImageTag`].ParameterValue' \
+    --output text)
+
+  echo "📦 Getting ECS cluster name..."
+  CLUSTER_NAME="${STACK_NAME}-cluster"
+
+  echo "🚀 Getting ECS service name..."
+  SERVICE_NAME="${STACK_NAME}-ecs-service"
+
+  echo "⏳ Waiting for service to stabilize..."
+  aws ecs wait services-stable \
+    --cluster "${CLUSTER_NAME}" \
+    --services "${SERVICE_NAME}"
+
+  echo "🐳 Getting running container version..."
+  TASK_ARN=$(aws ecs list-tasks \
+    --cluster $CLUSTER_NAME \
+    --service-name $SERVICE_NAME \
+    --query 'taskArns[0]' \
+    --output text)
+
+  CONTAINER_VERSION=$(aws ecs describe-tasks \
+    --cluster $CLUSTER_NAME \
+    --tasks $TASK_ARN \
+    --query 'tasks[0].containers[0].image' \
+    --output text | cut -d':' -f2)
+
+  echo "\n📊 Current versions:"
+  echo "├─ Stack parameter version: $STACK_VERSION"
+  echo "└─ Running container version: $CONTAINER_VERSION"
+  echo "----------------------------------------\n"
+}
+
+function invoke_updater() {
+  echo "🔍 Looking for AutoUpdate Lambda in stack: $STACK_NAME"
+  LAMBDA_NAME=$(aws cloudformation describe-stack-resources \
+    --stack-name $STACK_NAME \
+    --query "StackResources[?ResourceType=='AWS::Lambda::Function' && contains(LogicalResourceId, 'AutoUpdate')].PhysicalResourceId" \
+    --output text)
+
+  if [ -z "$LAMBDA_NAME" ]; then
+    echo "❌ AutoUpdate Lambda function not found in stack. This might be because:"
+    echo "  - The stack name is incorrect"
+    echo "  - Auto-updates were not enabled for this stack"
+    echo "  - The Lambda function hasn't been created yet"
+    exit 1
+  fi
+
+  echo "📦 Found Lambda: $LAMBDA_NAME"
+  echo "------------------------------------------------"
+
+  # Invoke the Lambda function
+  echo "🚀 Invoking Lambda function..."
+  local payload='{
+    "source": "aws.events",
+    "detail-type": "Scheduled Event",
+    "detail": {}
+  }'
+  RESPONSE=$(aws lambda invoke \
+    --log-type Tail \
+    --cli-read-timeout 0 \
+    --function-name "$LAMBDA_NAME" \
+    --payload "$(echo "$payload" | base64)" \
+    /dev/stdout)
+  # Print the response regardless of exit code
+
+  if [ $? -eq 0 ]; then
+    echo "✅ Lambda function executed successfully"
+    echo "------------------------------------------------"
+
+    # Extract components using regex patterns
+    RESPONSE_JSON=$(echo "$RESPONSE" | sed -E 's/^(.*)\$LATEST.*[[:space:]]+[^[:space:]]+$/\1/')
+    BASE64_LOGS=$(echo "$RESPONSE" | sed -E 's/^.*\$LATEST[[:space:]]+([^[:space:]]+)[[:space:]]+[0-9]+$/\1/')
+    STATUS_CODE=$(echo "$RESPONSE" | sed -E 's/^.*[[:space:]]+([0-9]+)$/\1/')
+
+    # Parse and display the response JSON
+    echo "📊 Response:"
+    echo "$RESPONSE_JSON" | jq -r '.body' | jq '.'
+    echo
+
+    # Decode and display the logs
+    echo "📝 Execution Logs:"
+    echo "$BASE64_LOGS" | base64 -d
+    echo
+
+    # Display the status code
+    echo "🔢 Status Code: $STATUS_CODE"
+    echo "------------------------------------------------"
+  else
+    echo "❌ Failed to invoke Lambda function"
+    exit 1
+  fi
+
+  # Check if response contains statusCode 200
+  if [ "$(echo "$RESPONSE_JSON" | jq -r '.statusCode')" -eq 200 ]; then
+    echo "✅ Update check completed successfully"
+  else
+    echo "❌ Update check failed - response did not indicate success"
+    exit 1
+  fi
+}
+
+function create_stack() {
+
+  aws cloudformation deploy \
+    --template-file cf.yml \
+    --stack-name $STACK_NAME --capabilities CAPABILITY_IAM \
+    --parameter-overrides \
+    FactorioImageTag=$FACTORIO_IMAGE_TAG \
+    ServerState=$SERVER_STATE \
+    InstancePurchaseMode=Spot \
+    InstanceType="" \
+    SpotPrice=0.05 \
+    SpotMinMemoryMiB=2048 \
+    SpotMinVCpuCount=2 \
+    KeyPairName="factorio-server" \
+    YourIp="" \
+    HostedZoneId=$HOSTED_ZONE_ID \
+    RecordName=$RECORD_NAME \
+    EnableRcon=false \
+    DlcSpaceAge=true \
+    UpdateModsOnStart=true \
+    AutoUpdateServer=true
+  echo "Waiting for stack creation to complete..."
+  aws cloudformation wait stack-create-complete --stack-name $STACK_NAME
+
+  wait_for_stack_update
+}
+
+function wait_for_stack_update() {
+  echo "⏳ Waiting for stack update to complete..."
+  while true; do
+    STATUS=$(aws cloudformation describe-stacks \
+      --stack-name $STACK_NAME \
+      --query 'Stacks[0].StackStatus' \
+      --output text)
+
+    echo "📊 Current stack status: $STATUS"
+
+    # Check if we've reached a final state
+    case $STATUS in
+    *COMPLETE | *FAILED)
+      break
+      ;;
+    esac
+
+    sleep 10
+  done
+
+  # Check if the final state is a failure
+  if [[ $STATUS == *"ROLLBACK_COMPLETE"* ]]; then
+    echo "❌ Stack update failed and rolled back"
+    exit 1
+  elif [[ $STATUS == *"COMPLETE"* ]]; then
+    echo "✅ Stack update completed successfully"
+  else
+    echo "❌ Stack update failed with status: $STATUS"
+    exit 1
+  fi
+}
+
+function do_test() {
+
+  echo "🚀 Step 1: Creating initial stack with version 2.0.30..."
+  create_stack
+
+  echo "\n📊 Initial state:"
+  get_versions
+
+  echo "🔄 Step 2: Running auto-updater lambda for the first time..."
+  echo "📦 Running auto-updater lambda..."
+  invoke_updater
+
+  wait_for_stack_update
+
+  echo "\n📊 State after first update:"
+  get_versions
+
+  echo "🔄 Step 3: Running auto-updater lambda for the second time..."
+  invoke_updater
+
+  wait_for_stack_update
+
+  echo "\n📊 State after second update:"
+  get_versions
+
+  echo "✅ Test complete!\n"
+}
+
+if [ -z "$SKIP_E2E_TEST" ]; then
+  do_test
+else
+  echo "⏭️ Skipping E2E test due to SKIP_E2E_TEST being set"
+fi


### PR DESCRIPTION
Add an option to automatically update the sever upon a new release. The internet said that this usually happens around 7am eastern on a given day, so check at 7:30.

test plan:
sh tests\teste2eupdater.sh
```
🚀 Step 1: Creating initial stack with version 2.0.30...

Waiting for changeset to be created..
Waiting for stack create/update to complete
Successfully created/updated stack - factorio-server-test
Waiting for stack creation to complete...
⏳ Waiting for stack update to complete...
📊 Current stack status: CREATE_COMPLETE
✅ Stack update completed successfully

📊 Initial state:

🔍 Getting current stack parameters...
📦 Getting ECS cluster name...
🚀 Getting ECS service name...
⏳ Waiting for service to stabilize...
🐳 Getting running container version...

📊 Current versions:
├─ Stack parameter version: 2.0.30
└─ Running container version: 2.0.30
----------------------------------------

🔄 Step 2: Running auto-updater lambda for the first time...
📦 Running auto-updater lambda...
🔍 Looking for AutoUpdate Lambda in stack: factorio-server-test
📦 Found Lambda: factorio-server-test-AutoUpdateLambda-7cHBNcRmlEff
------------------------------------------------
🚀 Invoking Lambda function...
✅ Lambda function executed successfully
------------------------------------------------
📊 Response:
{
  "success": true,
  "message": "Stack update completed successfully",
  "oldVersion": "2.0.30",
  "newVersion": "2.0.32"
}

📝 Execution Logs:
START RequestId: a70b16ba-a3ce-4de3-b6db-7a0944ca886c Version: $LATEST
[INFO]  2025-01-29T00:59:04.361Z        a70b16ba-a3ce-4de3-b6db-7a0944ca886c    Found credentials in environment variables.
[INFO]  2025-01-29T00:59:07.660Z        a70b16ba-a3ce-4de3-b6db-7a0944ca886c    Current version: 2.0.30, Latest version: 2.0.32
[INFO]  2025-01-29T00:59:07.661Z        a70b16ba-a3ce-4de3-b6db-7a0944ca886c    Updating stack to latest version: 2.0.32
[INFO]  2025-01-29T00:59:08.166Z        a70b16ba-a3ce-4de3-b6db-7a0944ca886c    Stack update initiated with FactorioImageTag=2.0.32
[INFO]  2025-01-29T00:59:08.198Z        a70b16ba-a3ce-4de3-b6db-7a0944ca886c    Current stack status: UPDATE_IN_PROGRESS
[INFO]  2025-01-29T00:59:18.677Z        a70b16ba-a3ce-4de3-b6db-7a0944ca886c    Current stack status: UPDATE_IN_PROGRESS
[INFO]  2025-01-29T00:59:29.160Z        a70b16ba-a3ce-4de3-b6db-7a0944ca886c    Current stack status: UPDATE_IN_PROGRESS
[INFO]  2025-01-29T00:59:39.639Z        a70b16ba-a3ce-4de3-b6db-7a0944ca886c    Current stack status: UPDATE_IN_PROGRESS
[INFO]  2025-01-29T00:59:50.099Z        a70b16ba-a3ce-4de3-b6db-7a0944ca886c    Current stack status: UPDATE_IN_PROGRESS
[INFO]  2025-01-29T01:00:00.585Z        a70b16ba-a3ce-4de3-b6db-7a0944ca886c    Current stack status: UPDATE_IN_PROGRESS
[INFO]  2025-01-29T01:00:11.063Z        a70b16ba-a3ce-4de3-b6db-7a0944ca886c    Current stack status: UPDATE_IN_PROGRESS
[INFO]  2025-01-29T01:00:21.545Z        a70b16ba-a3ce-4de3-b6db-7a0944ca886c    Current stack status: UPDATE_IN_PROGRESS
[INFO]  2025-01-29T01:00:32.023Z        a70b16ba-a3ce-4de3-b6db-7a0944ca886c    Current stack status: UPDATE_IN_PROGRESS
[INFO]  2025-01-29T01:00:42.501Z        a70b16ba-a3ce-4de3-b6db-7a0944ca886c    Current stack status: UPDATE_IN_PROGRESS
[INFO]  2025-01-29T01:00:52.983Z        a70b16ba-a3ce-4de3-b6db-7a0944ca886c    Update result: True, Message: Stack update completed successfully
END RequestId: a70b16ba-a3ce-4de3-b6db-7a0944ca886c
REPORT RequestId: a70b16ba-a3ce-4de3-b6db-7a0944ca886c  Duration: 108842.77 ms  Billed Duration: 108843 ms      Memory Size: 128 MB     Max Memory Used: 81 MB  Init Duration: 318.61 ms

🔢 Status Code: 200
------------------------------------------------
✅ Update check completed successfully
⏳ Waiting for stack update to complete...
📊 Current stack status: UPDATE_COMPLETE
✅ Stack update completed successfully

📊 State after first update:

🔍 Getting current stack parameters...
📦 Getting ECS cluster name...
🚀 Getting ECS service name...
⏳ Waiting for service to stabilize...
🐳 Getting running container version...

📊 Current versions:
├─ Stack parameter version: 2.0.32
└─ Running container version: 2.0.32
----------------------------------------

🔄 Step 3: Running auto-updater lambda for the second time...
🔍 Looking for AutoUpdate Lambda in stack: factorio-server-test
📦 Found Lambda: factorio-server-test-AutoUpdateLambda-7cHBNcRmlEff
------------------------------------------------
🚀 Invoking Lambda function...
✅ Lambda function executed successfully
------------------------------------------------
📊 Response:
{
  "success": true,
  "message": "No update needed - current version is 2.0.32",
  "currentVersion": "2.0.32"
}

📝 Execution Logs:
START RequestId: 430f45a2-d230-4fe6-9dd8-76759844f7cd Version: $LATEST
[INFO]  2025-01-29T01:00:57.924Z        430f45a2-d230-4fe6-9dd8-76759844f7cd    Current version: 2.0.32, Latest version: 2.0.32
[INFO]  2025-01-29T01:00:57.924Z        430f45a2-d230-4fe6-9dd8-76759844f7cd    No update needed - current version is 2.0.32
END RequestId: 430f45a2-d230-4fe6-9dd8-76759844f7cd
REPORT RequestId: 430f45a2-d230-4fe6-9dd8-76759844f7cd  Duration: 718.70 ms     Billed Duration: 719 ms Memory Size: 128 MB     Max Memory Used: 81 MB

🔢 Status Code: 200
------------------------------------------------
✅ Update check completed successfully
⏳ Waiting for stack update to complete...
📊 Current stack status: UPDATE_COMPLETE
✅ Stack update completed successfully

📊 State after second update:

🔍 Getting current stack parameters...
📦 Getting ECS cluster name...
🚀 Getting ECS service name...
⏳ Waiting for service to stabilize...
🐳 Getting running container version...

📊 Current versions:
├─ Stack parameter version: 2.0.32
└─ Running container version: 2.0.32
----------------------------------------

✅ Test complete!
```