### PR TITLE
[dnsupdater] Set the record as part of the instance start

### DIFF
--- a/cf.yml
+++ b/cf.yml
@@ -312,6 +312,30 @@ Resources:
           Fn::Base64: !Sub |
             #!/bin/bash -xe
             echo ECS_CLUSTER=${EcsCluster} >> /etc/ecs/ecs.config
+            
+            # Only run DNS update if DNS is enabled
+            if [ "${HostedZoneId}" != "" ] && [ "${RecordName}" != "" ]; then
+              # Install AWS CLI
+              yum install -y aws-cli
+              # Get instance ID and public IP
+              PUBLIC_IP=$(curl -s http://169.254.169.254/latest/meta-data/public-ipv4)
+              
+              # Update Route53 DNS record
+              aws route53 change-resource-record-sets \
+                --hosted-zone-id ${HostedZoneId} \
+                --change-batch '{
+                  "Changes": [{
+                    "Action": "UPSERT",
+                    "ResourceRecordSet": {
+                      "Name": "${RecordName}",
+                      "Type": "A",
+                      "TTL": 60,
+                      "ResourceRecords": [{"Value":"'$PUBLIC_IP'"}]
+                    }
+                  }]
+                }' \
+                --region ${AWS::Region}
+            fi
 
   AutoScalingGroup:
     Type: AWS::AutoScaling::AutoScalingGroup
@@ -420,106 +444,6 @@ Resources:
             Value: !Sub "${UpdateModsOnStart}"
           - Name: DLC_SPACE_AGE
             Value: !Sub "${DlcSpaceAge}"
-
-  # ====================================================
-  # SET DNS RECORD
-  # ====================================================
-
-  SetDNSRecordLambdaRole:
-    Type: AWS::IAM::Role
-    Condition: DnsConfigEnabled
-    Properties:
-      AssumeRolePolicyDocument:
-        Version: '2012-10-17'
-        Statement:
-        - Effect: Allow
-          Principal:
-            Service:
-            - lambda.amazonaws.com
-          Action:
-          - sts:AssumeRole
-      ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
-      Policies:
-        - PolicyName: root
-          PolicyDocument:
-            Version: "2012-10-17"
-            Statement:
-              - Effect: "Allow"
-                Action: "route53:*"
-                Resource: "*"
-              - Effect: "Allow"
-                Action: "ec2:DescribeInstance*"
-                Resource: "*"
-
-  SetDNSRecordLambda:
-    Type: "AWS::Lambda::Function"
-    Condition: DnsConfigEnabled
-    Properties:
-      Environment:
-        Variables:
-          HostedZoneId: !Ref HostedZoneId
-          RecordName: !Ref RecordName
-      Code:
-        ZipFile: |
-          import boto3
-          import os
-          def handler(event, context):
-            new_instance = boto3.resource('ec2').Instance(event['detail']['EC2InstanceId'])
-            boto3.client('route53').change_resource_record_sets(
-              HostedZoneId= os.environ['HostedZoneId'],
-              ChangeBatch={
-                  'Comment': 'updating',
-                  'Changes': [
-                      {
-                          'Action': 'UPSERT',
-                          'ResourceRecordSet': {
-                              'Name': os.environ['RecordName'],
-                              'Type': 'A',
-                              'TTL': 60,
-                              'ResourceRecords': [
-                                  {
-                                      'Value': new_instance.public_ip_address
-                                  },
-                              ]
-                          }
-                      },
-                  ]
-              })
-      Description: Sets Route 53 DNS Record for Factorio
-      FunctionName: !Sub "${AWS::StackName}-set-dns"
-      Handler: index.handler
-      MemorySize: 128
-      Role: !GetAtt SetDNSRecordLambdaRole.Arn
-      Runtime: python3.12
-      Timeout: 20
-
-  LaunchEvent:
-    Type: AWS::Events::Rule
-    Condition: DnsConfigEnabled
-    Properties:
-      EventPattern:
-        source:
-        - aws.autoscaling
-        detail-type:
-        - EC2 Instance Launch Successful
-        detail:
-          AutoScalingGroupName:
-          - !Ref AutoScalingGroup
-      Name: !Sub "${AWS::StackName}-instance-launch"
-      State: ENABLED
-      Targets:
-        - Arn: !GetAtt SetDNSRecordLambda.Arn
-          Id: !Sub "${AWS::StackName}-set-dns"
-
-  LaunchEventLambdaPermission:
-    Type: AWS::Lambda::Permission
-    Condition: DnsConfigEnabled
-    Properties:
-      Action: lambda:InvokeFunction
-      FunctionName: !GetAtt SetDNSRecordLambda.Arn
-      Principal: events.amazonaws.com
-      SourceArn: !GetAtt LaunchEvent.Arn
 
 Outputs:
   CheckInstanceIp:


### PR DESCRIPTION
Move the DNS configuration to the instance start config, versus a lambda / cloudbridge. This is a bunch simpler, and seems to work to resolve the issue where DNS updates were initermittenly failing (I think it was a race condition where the ec2 instance would come up before the lambda was plumbed correctly.)

🙏 to @ZoesDev for the idea to move this to a LaunchTemplate

fixes m-chandler/factorio-spot-pricing#49

Test Plan:
* Started up instance w/o DNS enabled, ensured record was not created, checked logs to ensure no updates were attempted
```
[ec2-user@ip-10-100-0-25 log]$ sudo cat cloud-init-output.log
Cloud-init v. 19.3-46.amzn2.0.4 running 'init-local' at Fri, 31 Jan 2025 02:18:41 +0000. Up 7.50 seconds.
Cloud-init v. 19.3-46.amzn2.0.4 running 'init' at Fri, 31 Jan 2025 02:18:42 +0000. Up 8.69 seconds.
ci-info: +++++++++++++++++++++++++++++++++++++++Net device info++++++++++++++++++++++++++++++++++++++++
ci-info: +--------+------+-----------------------------+-----------------+--------+-------------------+
ci-info: | Device |  Up  |           Address           |       Mask      | Scope  |     Hw-Address    |
ci-info: +--------+------+-----------------------------+-----------------+--------+-------------------+
ci-info: |  eth0  | True |         10.100.0.25         | 255.255.255.240 | global | 06:96:e0:e4:cc:a9 |
ci-info: |  eth0  | True | fe80::496:e0ff:fee4:cca9/64 |        .        |  link  | 06:96:e0:e4:cc:a9 |
ci-info: |   lo   | True |          127.0.0.1          |    255.0.0.0    |  host  |         .         |
ci-info: |   lo   | True |           ::1/128           |        .        |  host  |         .         |
ci-info: +--------+------+-----------------------------+-----------------+--------+-------------------+
ci-info: ++++++++++++++++++++++++++++++++Route IPv4 info++++++++++++++++++++++++++++++++
ci-info: +-------+-----------------+-------------+-----------------+-----------+-------+
ci-info: | Route |   Destination   |   Gateway   |     Genmask     | Interface | Flags |
ci-info: +-------+-----------------+-------------+-----------------+-----------+-------+
ci-info: |   0   |     0.0.0.0     | 10.100.0.17 |     0.0.0.0     |    eth0   |   UG  |
ci-info: |   1   |   10.100.0.16   |   0.0.0.0   | 255.255.255.240 |    eth0   |   U   |
ci-info: |   2   | 169.254.169.254 |   0.0.0.0   | 255.255.255.255 |    eth0   |   UH  |
ci-info: +-------+-----------------+-------------+-----------------+-----------+-------+
ci-info: +++++++++++++++++++Route IPv6 info+++++++++++++++++++
ci-info: +-------+-------------+---------+-----------+-------+
ci-info: | Route | Destination | Gateway | Interface | Flags |
ci-info: +-------+-------------+---------+-----------+-------+
ci-info: |   9   |  fe80::/64  |    ::   |    eth0   |   U   |
ci-info: |   11  |    local    |    ::   |    eth0   |   U   |
ci-info: |   12  |   ff00::/8  |    ::   |    eth0   |   U   |
ci-info: +-------+-------------+---------+-----------+-------+
Cloud-init v. 19.3-46.amzn2.0.4 running 'modules:config' at Fri, 31 Jan 2025 02:18:44 +0000. Up 10.39 seconds.
Cloud-init v. 19.3-46.amzn2.0.4 running 'modules:final' at Fri, 31 Jan 2025 02:18:44 +0000. Up 11.11 seconds.
+ echo ECS_CLUSTER=factorio-server-test-no-dns-cluster
+ '[' Z0310152ZY0AOO6U2SBH '!=' '' ']'
+ '[' '' '!=' '' ']'
Cloud-init v. 19.3-46.amzn2.0.4 finished at Fri, 31 Jan 2025 02:18:45 +0000. Datasource DataSourceEc2.  Up 11.44 seconds
```

* Started up instance w/dns enabled, validated that record was created
```
[ec2-user@ip-10-100-0-20 ~]$ sudo cat /var/log/cloud-init-output.log
Cloud-init v. 19.3-46.amzn2.0.4 running 'init-local' at Fri, 31 Jan 2025 02:29:58 +0000. Up 6.86 seconds.
Cloud-init v. 19.3-46.amzn2.0.4 running 'init' at Fri, 31 Jan 2025 02:29:59 +0000. Up 8.02 seconds.
ci-info: +++++++++++++++++++++++++++++++++++++++Net device info++++++++++++++++++++++++++++++++++++++++
ci-info: +--------+------+-----------------------------+-----------------+--------+-------------------+
ci-info: | Device |  Up  |           Address           |       Mask      | Scope  |     Hw-Address    |
ci-info: +--------+------+-----------------------------+-----------------+--------+-------------------+
ci-info: |  eth0  | True |         10.100.0.20         | 255.255.255.240 | global | 06:bc:bc:79:75:a3 |
ci-info: |  eth0  | True | fe80::4bc:bcff:fe79:75a3/64 |        .        |  link  | 06:bc:bc:79:75:a3 |
ci-info: |   lo   | True |          127.0.0.1          |    255.0.0.0    |  host  |         .         |
ci-info: |   lo   | True |           ::1/128           |        .        |  host  |         .         |
ci-info: +--------+------+-----------------------------+-----------------+--------+-------------------+
ci-info: ++++++++++++++++++++++++++++++++Route IPv4 info++++++++++++++++++++++++++++++++
ci-info: +-------+-----------------+-------------+-----------------+-----------+-------+
ci-info: | Route |   Destination   |   Gateway   |     Genmask     | Interface | Flags |
ci-info: +-------+-----------------+-------------+-----------------+-----------+-------+
ci-info: |   0   |     0.0.0.0     | 10.100.0.17 |     0.0.0.0     |    eth0   |   UG  |
ci-info: |   1   |   10.100.0.16   |   0.0.0.0   | 255.255.255.240 |    eth0   |   U   |
ci-info: |   2   | 169.254.169.254 |   0.0.0.0   | 255.255.255.255 |    eth0   |   UH  |
ci-info: +-------+-----------------+-------------+-----------------+-----------+-------+
ci-info: +++++++++++++++++++Route IPv6 info+++++++++++++++++++
ci-info: +-------+-------------+---------+-----------+-------+
ci-info: | Route | Destination | Gateway | Interface | Flags |
ci-info: +-------+-------------+---------+-----------+-------+
ci-info: |   9   |  fe80::/64  |    ::   |    eth0   |   U   |
ci-info: |   11  |    local    |    ::   |    eth0   |   U   |
ci-info: |   12  |   ff00::/8  |    ::   |    eth0   |   U   |
ci-info: +-------+-------------+---------+-----------+-------+
Cloud-init v. 19.3-46.amzn2.0.4 running 'modules:config' at Fri, 31 Jan 2025 02:30:01 +0000. Up 9.78 seconds.
Cloud-init v. 19.3-46.amzn2.0.4 running 'modules:final' at Fri, 31 Jan 2025 02:30:02 +0000. Up 10.52 seconds.
+ echo ECS_CLUSTER=factorio-server-test-dns-cluster
+ '[' *********'!=' '' ']'
+ '[' *********'!=' '' ']'
+ yum install -y aws-cli
Loaded plugins: priorities, update-motd, upgrade-helper
Resolving Dependencies
--> Running transaction check
---> Package awscli.noarch 0:1.18.147-1.amzn2.0.2 will be installed
--> Processing Dependency: python2-botocore = 1.18.6 for package: awscli-1.18.147-1.amzn2.0.2.noarch
--> Processing Dependency: python-colorama for package: awscli-1.18.147-1.amzn2.0.2.noarch
--> Processing Dependency: python-docutils for package: awscli-1.18.147-1.amzn2.0.2.noarch
--> Processing Dependency: python-rsa for package: awscli-1.18.147-1.amzn2.0.2.noarch
--> Processing Dependency: python2-s3transfer for package: awscli-1.18.147-1.amzn2.0.2.noarch
--> Running transaction check
---> Package python-docutils.noarch 0:0.12-0.2.20140510svn7747.amzn2 will be installed
--> Processing Dependency: python-imaging for package: python-docutils-0.12-0.2.20140510svn7747.amzn2.noarch
---> Package python2-botocore.noarch 0:1.18.6-1.amzn2.0.3 will be installed
--> Processing Dependency: python-dateutil >= 1.4 for package: python2-botocore-1.18.6-1.amzn2.0.3.noarch
--> Processing Dependency: python-jmespath >= 0.9.3 for package: python2-botocore-1.18.6-1.amzn2.0.3.noarch
---> Package python2-colorama.noarch 0:0.3.9-3.amzn2.0.1 will be installed
---> Package python2-rsa.noarch 0:3.4.1-1.amzn2.0.4 will be installed
---> Package python2-s3transfer.noarch 0:0.3.3-1.amzn2.0.1 will be installed
--> Processing Dependency: python-futures for package: python2-s3transfer-0.3.3-1.amzn2.0.1.noarch
--> Running transaction check
---> Package python-pillow.x86_64 0:2.0.0-23.gitd1c6db8.amzn2.0.13 will be installed
--> Processing Dependency: libjpeg.so.62(LIBJPEG_6.2)(64bit) for package: python-pillow-2.0.0-23.gitd1c6db8.amzn2.0.13.x86_64
--> Processing Dependency: libtiff.so.5(LIBTIFF_4.0)(64bit) for package: python-pillow-2.0.0-23.gitd1c6db8.amzn2.0.13.x86_64
--> Processing Dependency: libjpeg.so.62()(64bit) for package: python-pillow-2.0.0-23.gitd1c6db8.amzn2.0.13.x86_64
--> Processing Dependency: libtiff.so.5()(64bit) for package: python-pillow-2.0.0-23.gitd1c6db8.amzn2.0.13.x86_64
--> Processing Dependency: libwebp.so.4()(64bit) for package: python-pillow-2.0.0-23.gitd1c6db8.amzn2.0.13.x86_64
---> Package python2-dateutil.noarch 1:2.6.1-3.amzn2 will be installed
---> Package python2-futures.noarch 0:3.0.5-1.amzn2 will be installed
---> Package python2-jmespath.noarch 0:0.9.3-1.amzn2.0.2 will be installed
--> Running transaction check
---> Package libjpeg-turbo.x86_64 0:2.0.90-2.amzn2.0.6 will be installed
---> Package libtiff.x86_64 0:4.0.3-35.amzn2.0.22 will be installed
--> Processing Dependency: libjbig.so.2.0()(64bit) for package: libtiff-4.0.3-35.amzn2.0.22.x86_64
---> Package libwebp.x86_64 0:0.3.0-10.amzn2.0.2 will be installed
--> Running transaction check
---> Package jbigkit-libs.x86_64 0:2.0-11.amzn2.0.3 will be installed
--> Finished Dependency Resolution

Dependencies Resolved

================================================================================
 Package             Arch    Version                          Repository   Size
================================================================================
Installing:
 awscli              noarch  1.18.147-1.amzn2.0.2             amzn2-core  2.1 M
Installing for dependencies:
 jbigkit-libs        x86_64  2.0-11.amzn2.0.3                 amzn2-core   47 k
 libjpeg-turbo       x86_64  2.0.90-2.amzn2.0.6               amzn2-core  171 k
 libtiff             x86_64  4.0.3-35.amzn2.0.22              amzn2-core  176 k
 libwebp             x86_64  0.3.0-10.amzn2.0.2               amzn2-core  170 k
 python-docutils     noarch  0.12-0.2.20140510svn7747.amzn2   amzn2-core  1.5 M
 python-pillow       x86_64  2.0.0-23.gitd1c6db8.amzn2.0.13   amzn2-core  447 k
 python2-botocore    noarch  1.18.6-1.amzn2.0.3               amzn2-core  4.4 M
 python2-colorama    noarch  0.3.9-3.amzn2.0.1                amzn2-core   30 k
 python2-dateutil    noarch  1:2.6.1-3.amzn2                  amzn2-core  251 k
 python2-futures     noarch  3.0.5-1.amzn2                    amzn2-core   27 k
 python2-jmespath    noarch  0.9.3-1.amzn2.0.2                amzn2-core   42 k
 python2-rsa         noarch  3.4.1-1.amzn2.0.4                amzn2-core   67 k
 python2-s3transfer  noarch  0.3.3-1.amzn2.0.1                amzn2-core  104 k

Transaction Summary
================================================================================
Install  1 Package (+13 Dependent packages)

Total download size: 9.5 M
Installed size: 65 M
Downloading packages:
--------------------------------------------------------------------------------
Total                                               26 MB/s | 9.5 MB  00:00
Running transaction check
Running transaction test
Transaction test succeeded
Running transaction
  Installing : libjpeg-turbo-2.0.90-2.amzn2.0.6.x86_64                     1/14
  Installing : python2-rsa-3.4.1-1.amzn2.0.4.noarch                        2/14
  Installing : python2-jmespath-0.9.3-1.amzn2.0.2.noarch                   3/14
  Installing : libwebp-0.3.0-10.amzn2.0.2.x86_64                           4/14
  Installing : jbigkit-libs-2.0-11.amzn2.0.3.x86_64                        5/14
  Installing : libtiff-4.0.3-35.amzn2.0.22.x86_64                          6/14
  Installing : python-pillow-2.0.0-23.gitd1c6db8.amzn2.0.13.x86_64         7/14
  Installing : python-docutils-0.12-0.2.20140510svn7747.amzn2.noarch       8/14
  Installing : python2-colorama-0.3.9-3.amzn2.0.1.noarch                   9/14
  Installing : 1:python2-dateutil-2.6.1-3.amzn2.noarch                    10/14
  Installing : python2-botocore-1.18.6-1.amzn2.0.3.noarch                 11/14
  Installing : python2-futures-3.0.5-1.amzn2.noarch                       12/14
  Installing : python2-s3transfer-0.3.3-1.amzn2.0.1.noarch                13/14
  Installing : awscli-1.18.147-1.amzn2.0.2.noarch                         14/14
  Verifying  : libjpeg-turbo-2.0.90-2.amzn2.0.6.x86_64                     1/14
  Verifying  : python2-s3transfer-0.3.3-1.amzn2.0.1.noarch                 2/14
  Verifying  : python2-futures-3.0.5-1.amzn2.noarch                        3/14
  Verifying  : 1:python2-dateutil-2.6.1-3.amzn2.noarch                     4/14
  Verifying  : python2-colorama-0.3.9-3.amzn2.0.1.noarch                   5/14
  Verifying  : jbigkit-libs-2.0-11.amzn2.0.3.x86_64                        6/14
  Verifying  : python2-botocore-1.18.6-1.amzn2.0.3.noarch                  7/14
  Verifying  : awscli-1.18.147-1.amzn2.0.2.noarch                          8/14
  Verifying  : libwebp-0.3.0-10.amzn2.0.2.x86_64                           9/14
  Verifying  : python-pillow-2.0.0-23.gitd1c6db8.amzn2.0.13.x86_64        10/14
  Verifying  : libtiff-4.0.3-35.amzn2.0.22.x86_64                         11/14
  Verifying  : python2-jmespath-0.9.3-1.amzn2.0.2.noarch                  12/14
  Verifying  : python2-rsa-3.4.1-1.amzn2.0.4.noarch                       13/14
  Verifying  : python-docutils-0.12-0.2.20140510svn7747.amzn2.noarch      14/14

Installed:
  awscli.noarch 0:1.18.147-1.amzn2.0.2

Dependency Installed:
  jbigkit-libs.x86_64 0:2.0-11.amzn2.0.3
  libjpeg-turbo.x86_64 0:2.0.90-2.amzn2.0.6
  libtiff.x86_64 0:4.0.3-35.amzn2.0.22
  libwebp.x86_64 0:0.3.0-10.amzn2.0.2
  python-docutils.noarch 0:0.12-0.2.20140510svn7747.amzn2
  python-pillow.x86_64 0:2.0.0-23.gitd1c6db8.amzn2.0.13
  python2-botocore.noarch 0:1.18.6-1.amzn2.0.3
  python2-colorama.noarch 0:0.3.9-3.amzn2.0.1
  python2-dateutil.noarch 1:2.6.1-3.amzn2
  python2-futures.noarch 0:3.0.5-1.amzn2
  python2-jmespath.noarch 0:0.9.3-1.amzn2.0.2
  python2-rsa.noarch 0:3.4.1-1.amzn2.0.4
  python2-s3transfer.noarch 0:0.3.3-1.amzn2.0.1

Complete!
++ curl -s http://169.254.169.254/latest/meta-data/public-ipv4
+ PUBLIC_IP=52.3.245.247
+ aws route53 change-resource-record-sets --hosted-zone-id ************* --change-batch '{
      "Changes": [{
        "Action": "UPSERT",
        "ResourceRecordSet": {
          "Name": "********",
          "Type": "A",
          "TTL": 60,
          "ResourceRecords": [{"Value":"52.3.245.247"}]
        }
      }]
    }' --region us-east-1
{
    "ChangeInfo": {
        "Status": "PENDING",
        "SubmittedAt": "2025-01-31T02:30:14.384Z",
        "Id": "/change/C01602392ZGS41I7W320O"
    }
}
Cloud-init v. 19.3-46.amzn2.0.4 finished at Fri, 31 Jan 2025 02:30:14 +0000. Datasource DataSourceEc2.  Up 22.77 seconds
```